### PR TITLE
fix start command to nohup

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 su - << EOF
 cd /home/centos/deploy/ThreeGoodThings-API
-yarn production
+nohup yarn production &
 EOF


### PR DESCRIPTION
startスクリプト内で`yarn production`(`yarn start`とほぼ同じ)を呼んでいたが、`yarn start`は起動中走り続けるコマンドなので、startスクリプトが終了したとみなされず、startがうまく行かなかった。
`nohup yarn production &`に変更します。